### PR TITLE
Only select valid characters from the authenticate header

### DIFF
--- a/src/client/axios.ts
+++ b/src/client/axios.ts
@@ -66,8 +66,8 @@ export function setupL402Interceptor(instance: AxiosInstance, wallet: Wallet, st
  */
 function parseHeader(header: string): { header_key: string; invoice: string; macaroon: string } | null {
   const headerKeyMatch = /^(LSAT|L402)/.exec(header);
-  const invoiceMatch = /invoice="([^"]+)"/.exec(header);
-  const macaroonMatch = /macaroon="([^"]+)"/.exec(header);
+  const invoiceMatch = /invoice="([\w|\d]+)"/.exec(header); // Lightning invoice only use alphanumeric characters, see: https://github.com/lightning/bolts/blob/master/11-payment-encoding.md
+  const macaroonMatch = /macaroon="([\w|\d\+\/=_-]+)"/.exec(header); // Base64 URL-safe characters
 
   if (invoiceMatch && macaroonMatch) {
     return {

--- a/test/client/axios.spec.js
+++ b/test/client/axios.spec.js
@@ -72,7 +72,7 @@ class MockWallet extends Wallet {
       const url = 'https://example.com/resource';
       nock('https://example.com')
         .get('/resource')
-        .reply(402, '', { 'www-authenticate': 'L402 invoice="mock-invoice" macaroon="mock-macaroon"' });
+        .reply(402, '', { 'www-authenticate': 'L402 invoice="mockinvoice" macaroon="mock-macaroon"' });
   
       // Mock the successful retry response
       nock('https://example.com')


### PR DESCRIPTION
Do not use the data if L402 endpoints are sending malformed or malicious content in the header.